### PR TITLE
bug in skip()?

### DIFF
--- a/lazy.js
+++ b/lazy.js
@@ -92,8 +92,11 @@ function Lazy (em, opts) {
 
     self.skip = function (n) {
         return newLazy(function () {
-            if (n-- == 0) return true;
-            return false;
+            if (n > 0) {
+                n--;
+                return false;
+            }
+            return true;
         });
     }
 

--- a/test/skip.js
+++ b/test/skip.js
@@ -1,0 +1,27 @@
+var assert = require('assert');
+var Lazy = require('lazy');
+var expresso = expresso;
+
+function range(i, j) {
+    var r = [];
+    for (;i<j;i++) r.push(i);
+    return r;
+}
+
+exports['skip'] = function () {
+    var lazy = new Lazy;
+    var data = [];
+    var executed = 0;
+    lazy.skip(6).join(function (xs) {
+        assert.deepEqual(xs, range(6,10));
+        executed++;
+    });
+
+    range(0,10).forEach(function (x) {
+        lazy.emit('data', x);
+    });
+    lazy.emit('end');
+
+    assert.equal(executed, 1, 'join executed incorrectly');
+}
+


### PR DESCRIPTION
Not sure what is skip()'s intentional behavior, but the current implementation returns only the n+1-th element and stops because of the (n--==0) check.  I think it should return everything after n-th element, and here is my patch.
