### PR TITLE
Make 'npm test' work

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     },
     "engines": {
         "node": ">=0.2.0"
+    },
+    "scripts": {
+        "test": "expresso"
     }
 }
 

--- a/test/bucket.js
+++ b/test/bucket.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var Lazy = require('lazy');
+var Lazy = require('..');
 
 exports.bucket = function () {
     var joined = false;

--- a/test/complex.js
+++ b/test/complex.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var Lazy = require('lazy');
+var Lazy = require('..');
 var expresso = expresso;
 
 function range(i, j) {

--- a/test/custom.js
+++ b/test/custom.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var Lazy = require('lazy');
+var Lazy = require('..');
 var expresso = expresso;
 
 function range(i, j) {

--- a/test/em.js
+++ b/test/em.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var Lazy = require('lazy');
+var Lazy = require('..');
 var EventEmitter = require('events').EventEmitter;
 
 function range(i, j) {

--- a/test/filter.js
+++ b/test/filter.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var Lazy = require('lazy');
+var Lazy = require('..');
 var expresso = expresso;
 
 function range(i, j) {

--- a/test/foldr.js
+++ b/test/foldr.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var Lazy = require('lazy');
+var Lazy = require('..');
 var expresso = expresso;
 
 function range(i, j) {

--- a/test/forEach.js
+++ b/test/forEach.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var Lazy = require('lazy');
+var Lazy = require('..');
 var expresso = expresso;
 
 function range(i, j) {

--- a/test/head.js
+++ b/test/head.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var Lazy = require('lazy');
+var Lazy = require('..');
 var expresso = expresso;
 
 function range(i, j) {

--- a/test/join.js
+++ b/test/join.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var Lazy = require('lazy');
+var Lazy = require('..');
 var expresso = expresso;
 
 function range(i, j) {

--- a/test/lines.js
+++ b/test/lines.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var Lazy = require('lazy');
+var Lazy = require('..');
 var EventEmitter = require('events').EventEmitter;
 
 exports['buffered lines'] = function () {

--- a/test/map.js
+++ b/test/map.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var Lazy = require('lazy');
+var Lazy = require('..');
 var expresso = expresso;
 
 function range(i, j) {

--- a/test/pipe.js
+++ b/test/pipe.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var Lazy = require('lazy');
+var Lazy = require('..');
 var EventEmitter = require('events').EventEmitter;
 
 function range(i, j) {

--- a/test/product.js
+++ b/test/product.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var Lazy = require('lazy');
+var Lazy = require('..');
 var expresso = expresso;
 
 function range(i, j) {

--- a/test/range.js
+++ b/test/range.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var Lazy = require('lazy');
+var Lazy = require('..');
 var expresso = expresso;
 
 function range(i, j, s) {

--- a/test/skip.js
+++ b/test/skip.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var Lazy = require('lazy');
+var Lazy = require('..');
 var expresso = expresso;
 
 function range(i, j) {

--- a/test/sum.js
+++ b/test/sum.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var Lazy = require('lazy');
+var Lazy = require('..');
 var expresso = expresso;
 
 function range(i, j) {

--- a/test/tail.js
+++ b/test/tail.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var Lazy = require('lazy');
+var Lazy = require('..');
 var expresso = expresso;
 
 function range(i, j) {

--- a/test/take.js
+++ b/test/take.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var Lazy = require('lazy');
+var Lazy = require('..');
 var expresso = expresso;
 
 function range(i, j) {

--- a/test/takeWhile.js
+++ b/test/takeWhile.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var Lazy = require('lazy');
+var Lazy = require('..');
 var expresso = expresso;
 
 function range(i, j) {


### PR DESCRIPTION
This patch adds a command to package.json calling 'expresso'.
It also changes all require('lazy') to require('..') as all require()s within a package should be relative.
