### PR TITLE
Made the 'endName' event to be spreaded over the chain of lazy objects.

### DIFF
--- a/lazy.js
+++ b/lazy.js
@@ -48,6 +48,9 @@ function Lazy (em, opts) {
         self.once(pipeName, function () {
             lazy.emit(pipeName)
         });
+        self.once(endName, function () {
+            lazy.emit(endName)
+        });
         return lazy;
     }
 
@@ -164,8 +167,9 @@ function Lazy (em, opts) {
         
         // flush on end event
         self.once(endName, function () {
-          var finalBuffer = mergeBuffers(acc);
-          if(finalBuffer) yield(finalBuffer);
+            var finalBuffer = mergeBuffers(acc);
+            if(finalBuffer) yield(finalBuffer);
+            lazy.emit(endName)
         });
         
         return lazy;


### PR DESCRIPTION
The commit made the 'endName' event to be spreaded over the chain of lazy objects.

So it can be used such as:

new lazy(.....)
        .lines
        .forEach(.....)
        .on('end', ->
          doSomething()
        )
