### PR TITLE
if line is blank don't return the end of line characters

### DIFF
--- a/lazy.js
+++ b/lazy.js
@@ -189,7 +189,11 @@ function Lazy (em, opts) {
                   if(i === lastNewLineIndex){
                     lastNewLineIndex = i-1;
                   }
-                  chunkArray.push(chunk.slice(lastNewLineIndex, i));
+
+                  // If the line is empty then the only item will be a new line
+                  if(i - lastNewLineIndex !== 1 || newline.indexOf(chunk[lastNewLineIndex]) === -1) {
+                    chunkArray.push(chunk.slice(lastNewLineIndex, i));
+                  }
                 } 
                 
                 // Skip second separator byte on \r\n terminated lines ( yeah, stupid DOS / Windows, I know... )
@@ -306,7 +310,7 @@ Lazy.range = function () {
 
 var mergeBuffers = function mergeBuffers(buffers) {
   // We expect buffers to be a non-empty Array
-  if (!buffers || !Array.isArray(buffers) || !buffers.length) return;
+  if (!buffers || !Array.isArray(buffers) || !buffers.length) return new Buffer(0);
   
   var finalBufferLength, finalBuffer, currentBuffer, currentSize = 0;
   

--- a/test/lines.js
+++ b/test/lines.js
@@ -87,3 +87,29 @@ exports.endStream = function () {
         em.emit('end');
     }, 200);
 };
+
+exports.emptyLines = function () {
+    var lineNumber = 0;
+    var em = new EventEmitter;
+    var lazy = Lazy(em);
+    lazy.lines
+      .map(String)
+      .forEach(function (line) {
+          switch(lineNumber) {
+          case 0:
+            assert.eql(line, 'line1');
+            break;
+          case 1:
+          case 2:
+            assert.eql(line, '');
+            assert.eql(line, '');
+            break;
+          case 3:
+            assert.eql(line, 'line4');
+            break;
+          }
+          lineNumber ++;
+      });
+    em.emit('data', 'line1\n\n\r\nline4');
+    em.emit('end');
+};


### PR DESCRIPTION
This fixes and issue when dealing with empty lines in stream. If your data has "line1\n\nline2" before this patch it would return "line1", "\n", "line2". This patch changes this behavior to return "line1", "", "line2"
