### PR TITLE
Remove v0.10 check

### DIFF
--- a/lazy.js
+++ b/lazy.js
@@ -43,18 +43,9 @@ function Lazy(em, opts) {
         self.on(pipeName, function () {
             em.emit(pipeName);
         });
-        // Check for v0.10 or Greater (Stream2 has Duplex type)
-        if (stream.Duplex && em instanceof(stream)) {
-            em.on('readable', function () {
-                var x = em.read();
-                self.emit(dataName, x);
-            });
-        } else {
-            // Old Stream1 or Event support
-            em.on(dataName, function (x) {
-                self.emit(dataName, x);
-            });
-        }
+        em.on(dataName, function (x) {
+            self.emit(dataName, x);
+        });
     }
 
     function newLazy (g, h, l) {


### PR DESCRIPTION
This fixes https://github.com/pkrumins/node-lazy/issues/32#issuecomment-20165665 for me and all the tests continue to pass under v0.10.x and v0.8.x

So either the behaviour was not needed - or it wasn't being covered by the tests. If it's the latter then this pull request may break when used with other streams, but I have no idea which ones.
