### PR TITLE
Fix and test for Issue #41

### DIFF
--- a/lazy.js
+++ b/lazy.js
@@ -333,7 +333,7 @@ var mergeBuffers = function mergeBuffers(buffers) {
   var finalBufferLength, finalBuffer, currentBuffer, currentSize = 0;
 
   // Sum all the buffers lengths
-  finalBufferLength = buffers.reduce(function(left, right) { return (left.length||left) + (right.length||right); }, 0);
+  finalBufferLength = buffers.reduce(function(left, right) { return left + right.length; }, 0);
   finalBuffer = new Buffer(finalBufferLength);
   while(buffers.length) {
     currentBuffer = buffers.shift();

--- a/test/lines.js
+++ b/test/lines.js
@@ -87,3 +87,11 @@ exports.endStream = function () {
         em.emit('end');
     }, 200);
 };
+
+exports.blankLine = function () {
+	var data = 'abc\n\ndef\n';
+	var l = Lazy();
+	l.lines.join(function (x) { assert.eql(x.join('\n') + '\n', data); });
+	l.emit('data', data);
+	l.emit('end');
+};


### PR DESCRIPTION
When `buffers` is an array of one buffer of zero length (falsey), this reduce operation ends up producing the string "0" in the output buffer. I couldn't find any reason the reduce operation needed to test either `left` or `right`, since `left` will always be a Number, and both places MergeBuffers is used it `buffers` elements will always have `length`. It still passes the entire test suite with this patch in place.
