### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,7 @@
         "web": "http://www.catonmat.net",
         "twitter": "pkrumins"
     }, 
-    "license": {
-            "type": "MIT"
-    }, 
+    "license": "MIT", 
     "repository": {
         "type": "git",
         "url": "http://github.com/pkrumins/node-lazy.git"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/
